### PR TITLE
Updates to Lucene search modules events

### DIFF
--- a/Modules/BetterCMS.Module.LuceneSearch/BetterCms.Module.LuceneSearch.csproj
+++ b/Modules/BetterCMS.Module.LuceneSearch/BetterCms.Module.LuceneSearch.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Models\Migrations\MigrationVersionMetaData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\IndexerService\DefaultIndexerService.cs" />
+    <Compile Include="Services\IndexerService\DocumentData.cs" />
     <Compile Include="Services\IndexerService\IIndexerService.cs" />
     <Compile Include="Services\IndexerService\PartialWordTermQueryParser.cs" />
     <Compile Include="Services\ScrapeService\DefaultScrapeService.cs" />

--- a/Modules/BetterCMS.Module.LuceneSearch/BetterCms.Module.LuceneSearch.csproj
+++ b/Modules/BetterCMS.Module.LuceneSearch/BetterCms.Module.LuceneSearch.csproj
@@ -43,6 +43,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>LuceneGlobalization.resx</DependentUpon>
     </Compile>
+    <Compile Include="Events\FetchingNewUrlsEventArgs.cs" />
     <Compile Include="Events\LuceneEvents.cs" />
     <Compile Include="Helpers\HtmlAgilityPackHelper.cs" />
     <Compile Include="Helpers\LuceneSearchHelper.cs" />

--- a/Modules/BetterCMS.Module.LuceneSearch/Events/DocumentSavingEventArgs.cs
+++ b/Modules/BetterCMS.Module.LuceneSearch/Events/DocumentSavingEventArgs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 
+using BetterCMS.Module.LuceneSearch.Services.IndexerService;
 using BetterCMS.Module.LuceneSearch.Services.WebCrawlerService;
 
 using Lucene.Net.Documents;
@@ -14,10 +16,16 @@ namespace BetterCms.Events
 
         public PageData PageData { get; set; }
 
+        public bool ExcludeDefaultDocumentFromIndex { get; set; }
+
+        public IList<DocumentData> AdditionalDocuments { get; set; }
+
         public DocumentSavingEventArgs(Document document, PageData pageData)
         {
             Document = document;
             PageData = pageData;
+            ExcludeDefaultDocumentFromIndex = false;
+            AdditionalDocuments = new List<DocumentData>();
         }
     }
 }

--- a/Modules/BetterCMS.Module.LuceneSearch/Events/FetchingNewUrlsEventArgs.cs
+++ b/Modules/BetterCMS.Module.LuceneSearch/Events/FetchingNewUrlsEventArgs.cs
@@ -1,0 +1,13 @@
+﻿using BetterCMS.Module.LuceneSearch.Models;
+using System;
+using System.Collections.Generic;
+
+// ReSharper disable CheckNamespace
+namespace BetterCms.Events
+// ReSharper restore CheckNamespace
+{
+    public class FetchingNewUrlsEventArgs: EventArgs
+    {
+        public IList<IndexSource> IndexSources { get; set; }
+    }
+}

--- a/Modules/BetterCMS.Module.LuceneSearch/Events/LuceneEvents.cs
+++ b/Modules/BetterCMS.Module.LuceneSearch/Events/LuceneEvents.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 
+using BetterCMS.Module.LuceneSearch.Models;
 using BetterCMS.Module.LuceneSearch.Services.WebCrawlerService;
 using BetterCms.Module.Search.Models;
 
@@ -28,6 +29,11 @@ namespace BetterCms.Events
         /// Occurs before document is saved.
         /// </summary>
         public event DefaultEventHandler<SearchResultRetrievingEventArgs> SearchResultRetrieving;
+
+        /// <summary>
+        /// Occurs before index sources are saved to database and allows to inject additional index sources.
+        /// </summary>
+        public event DefaultEventHandler<FetchingNewUrlsEventArgs> FetchingNewUrls;
 
         public DocumentSavingEventArgs OnDocumentSaving(Document document, PageData pageData)
         {
@@ -60,6 +66,18 @@ namespace BetterCms.Events
             if (SearchResultRetrieving != null)
             {
                 SearchResultRetrieving(args);
+            }
+
+            return args;
+        }
+
+        public FetchingNewUrlsEventArgs OnFetchingNewUrls()
+        {
+            var args = new FetchingNewUrlsEventArgs { IndexSources = new List<IndexSource>() };
+
+            if (FetchingNewUrls != null)
+            {
+                FetchingNewUrls(args);
             }
 
             return args;

--- a/Modules/BetterCMS.Module.LuceneSearch/LuceneSearchModuleDescriptor.cs
+++ b/Modules/BetterCMS.Module.LuceneSearch/LuceneSearchModuleDescriptor.cs
@@ -109,7 +109,7 @@ namespace BetterCms.Module.LuceneSearch
 
                     workers.ForEach(f => f.Start());
 
-                    Logger.Info("OnHostStart: preparing Lucene Search index workers completed.");
+                    Logger.InfoFormat("OnHostStart: started {0} Lucene Search workers.", workers.Count);
                 };
         }
         

--- a/Modules/BetterCMS.Module.LuceneSearch/Models/IndexSource.cs
+++ b/Modules/BetterCMS.Module.LuceneSearch/Models/IndexSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 using BetterModules.Core.DataContracts;
 using BetterModules.Core.Models;
@@ -20,5 +21,41 @@ namespace BetterCMS.Module.LuceneSearch.Models
         public virtual DateTime? NextRetryTime { get; set; }
         
         public virtual int FailedCount { get; set; }
+
+        /// <summary>
+        /// Compares two index sources based on the values of SourceId and Path properties.
+        /// </summary>
+        public class IndexSourceComparerByIdAndPath : IEqualityComparer<IndexSource>
+        {
+            /// <summary>
+            /// Index sources are equal is both SourceId and Path are equal
+            /// </summary>
+            public bool Equals(IndexSource x, IndexSource y)
+            {
+                // Check whether the compared objects reference the same data. 
+                if (Object.ReferenceEquals(x, y)) return true;
+
+                // Check whether any of the compared objects is null. 
+                if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
+                    return false;
+
+                // Check whether the codes are equal. 
+                return x.SourceId == y.SourceId && x.Path == y.Path;
+            }
+
+            /// <summary>
+            /// If Equals() returns true for a pair of objects  then GetHashCode() must return the same value for these objects. 
+            /// </summary>
+            public int GetHashCode(IndexSource source)
+            {
+                // Check whether the object is null 
+                if (Object.ReferenceEquals(source, null)) return 0;
+
+                var sourceIdHash = source.SourceId == null ? 0 : source.SourceId.GetHashCode();
+                var pathHash = source.Path == null ? 0 : source.Path.GetHashCode();
+
+                return sourceIdHash ^ pathHash;
+            }
+        }
     }
 }

--- a/Modules/BetterCMS.Module.LuceneSearch/Services/IndexerService/DocumentData.cs
+++ b/Modules/BetterCMS.Module.LuceneSearch/Services/IndexerService/DocumentData.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace BetterCMS.Module.LuceneSearch.Services.IndexerService
+{
+    public class DocumentData
+    {
+        public Guid Id { get; set; }
+        public string Path { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public bool IsPublished { get; set; }
+    }
+}


### PR DESCRIPTION
FetchingNewUrls event is fired after index sources are retrieved from BetterCMS DB but before the list is saved to DB. Event allows to inject additional index sources.
DocumentSaving event allows to control how documents are saved to Lucene index. Property ExcludeDefaultDocumentFromIndex controls whether current document is saved to index. AdditionalDocuments collection allow to save additional documents to index.