### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ﻿#Better CMS#
 A publishing focused and developer friendly .NET Open Source CMS.
 
-##Install##
+## Install ##
 To install Better CMS from Visual Studio type in Package Manager:
 <pre><code>Install-Package BetterCMS</code></pre>
 and follow [the setup instructions for the ASP.NET MVC 4 project](https://github.com/devbridge/BetterCMS/wiki/Setup-ASP.NET-MVC-4-project).
 
-##Demo##
+## Demo ##
 Latest released version is deployed to http://demo.bettercms.com.
 
-##License##
+## License ##
 Better CMS is licensed under [GNU LESSER GENERAL PUBLIC LICENSE](http://www.gnu.org/licenses/lgpl-3.0.txt).
 
-##Contacts##
+## Contacts ##
 Devbridge Group LLC<br/>
 343 W Erie St.<br/>
 Suite 600<br/>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
