### PR TITLE
HTML encode error messages shown to the users

### DIFF
--- a/Modules/BetterCms.Module.Pages/Accessors/ServerControlWidgetAccessor.cs
+++ b/Modules/BetterCms.Module.Pages/Accessors/ServerControlWidgetAccessor.cs
@@ -42,6 +42,7 @@ using BetterCms.Module.Root.ViewModels.Cms;
 using Common.Logging;
 
 using RazorGenerator.Mvc;
+using System.Web;
 
 namespace BetterCms.Module.Pages.Accessors
 {
@@ -189,7 +190,7 @@ namespace BetterCms.Module.Pages.Accessors
         //
         private static string GetErrorString(string view, string message)
         {
-            return string.Format(@"<div class=""bcms-error"">Error rendering view ""{0}"": {1}</div>", view, message);
+            return string.Format(@"<div class=""bcms-error"">Error rendering view ""{0}"": {1}</div>", view, HttpUtility.HtmlEncode(message));
         }
 
         private RenderWidgetViewModel CreateWidgetViewModel(IView view)


### PR DESCRIPTION
Since the error messages can contain data entered by the user, we need to
escape it when showing them back to the user.